### PR TITLE
Fix logger.error usage in basename utilities

### DIFF
--- a/apps/web/src/utils/redirectIfNameDoesNotExist.ts
+++ b/apps/web/src/utils/redirectIfNameDoesNotExist.ts
@@ -19,8 +19,7 @@ export async function redirectIfNameDoesNotExist(username: Basename) {
       getBasenameOwner(username),
     ]);
   } catch (error) {
-    logger.error('Error fetching basename address, editor, or owner', {
-      error,
+    logger.error('Error fetching basename address, editor, or owner', error, {
       username,
     });
     apiError = true;

--- a/apps/web/src/utils/usernames.ts
+++ b/apps/web/src/utils/usernames.ts
@@ -661,8 +661,7 @@ export async function getBasenameNameExpires(username: Basename) {
 
     return nameExpires;
   } catch (error) {
-    logger.error('Error fetching basename expiration date', {
-      error,
+    logger.error('Error fetching basename expiration date', error, {
       username,
       tokenId,
       chainId: chain.id,
@@ -851,8 +850,7 @@ export async function isBasenameInGracePeriod(username: Basename): Promise<boole
     // Name is in grace period if it's expired but within the grace period duration
     return timeSinceExpiration > 0 && timeSinceExpiration <= GRACE_PERIOD_DURATION_MS;
   } catch (error) {
-    logger.error('Error checking if basename is in grace period', {
-      error,
+    logger.error('Error checking if basename is in grace period', error, {
       username,
     });
     return false;


### PR DESCRIPTION
## Summary
- ensure caught exceptions in basename utilities are passed to `logger.error`
- keep contextual metadata when logging failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e536664b70832eb3ba1bddc786cc63